### PR TITLE
Allow plugins to be async

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ const swap = async (template, tags, formatter) => {
       const { default: code } = await mod
 
       // calculate the replacement
-      let replacement = formatter.filter(code.apply(null, tag.parameters))
+      let replacement = formatter.filter(await code.apply(null, tag.parameters))
 
       // apply filter
       if (tag.filter) {


### PR DESCRIPTION
Sorry, for the sudden fix.. it turns out, we have some custom plugins which are async too! 🤦🏻‍♂️

This fix allows plugins to return themselves async functions, which need to be awaited.