### PR TITLE
[RFC] Add extra filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ $ echo '{{ name | toLowerCase | sha256 }}' | datamaker
 - `sha1`
 - `sha256`
 - `base64`
+- `toFloat`
+- `toInt`
 - `toString`
 
 ## Tag reference

--- a/index.js
+++ b/index.js
@@ -102,6 +102,8 @@ const swap = async (template, tags, formatter) => {
       // calculate the replacement
       let replacement = formatter.filter(await code.apply(null, tag.parameters))
 
+      let original = tag.original;
+
       // apply filter
       if (tag.filter) {
         for (const j in tag.filter) {
@@ -135,6 +137,18 @@ const swap = async (template, tags, formatter) => {
             case 'base64':
               replacement = Buffer.from(replacement).toString('base64')
               break
+            case 'toBool':
+              replacement = replacement === 'true'
+              original = `"${tag.original}"`;
+              break
+            case 'toFloat':
+              replacement = parseFloat(replacement);
+              original = `"${tag.original}"`;
+              break
+            case 'toInt':
+              replacement = parseInt(replacement);
+              original = `"${tag.original}"`;
+              break
             case 'toString':
               replacement = replacement.toString()
               break
@@ -148,7 +162,7 @@ const swap = async (template, tags, formatter) => {
       cache.set(tag.tag, replacement)
 
       // switch the tag in the template for the replacement
-      str = str.replace(tag.original, replacement)
+      str = str.replace(original, replacement)
     }
   }
 


### PR DESCRIPTION
Hi @glynnbird!

Wondered your thoughts on this one, I find it an annoyance that the datamaker templates aren't valid JSON, e.g.

```json
{
  "alive": {{boolean 0.75}},
  "desc": "{{words 20}}",
  "id": {{integer}},
  "score": {{float 1 10 1}},
  "tel": "{{tel}}"
}
```

To get the required type in the output JSON the placeholders have to be unquoted which makes the template itself invalid JSON.

I toyed around with adding a few extra filters, namely, `toFloat`, `toBool` and `toInt` to allow the value to be replaced with the data type equivalent which then allows them to be quoted, i.e.:-

```json
{
  "alive": "{{boolean 0.75 | toBool}}",
  "desc": "{{words 20}}",
  "id": "{{integer | toInt}}",
  "score": "{{float 1 10 1 | toFloat}}",
  "tel": "{{tel}}"
}
```

Running the above gives:-

<img width="651" alt="image" src="https://user-images.githubusercontent.com/43741/208508856-57e2c30a-7957-488c-af53-be69a2ac76d6.png">

The plugins can still be unquoted without the formatters to retain the original behaviour and the additional formatters only work with an output JSON format.

Does this seem like a reasonable feature to add or can you think of a better way? Is the API obvious enough?

It basically allows our many `*.datamaker.json` files to be linted properly in our CI jobs.