### PR TITLE
Add toObject filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,9 +215,40 @@ $ echo '{{ name | toLowerCase | sha256 }}' | datamaker
 - `sha1`
 - `sha256`
 - `base64`
+- `toString`
+
+Additionally for JSON formats, the following filters can be used within
+templates to output appropriate JSON datatypes:-
+
+- `toBool`
 - `toFloat`
 - `toInt`
-- `toString`
+- `toObject`
+
+E.g. 
+
+```json
+{
+  "alive": "{{boolean 0.75 | toBool}}",
+  "count": "{{integer | toInt}}",
+  "score": "{{float | toFloat}}",
+  "address": "{{custom:plugin | toObject}}",
+}
+```
+
+Returns:-
+
+```json
+{
+  "alive": true,
+  "count": 10,
+  "score": 5.0,
+  "address": {
+    "street": "High Street",
+    "postcode": "PA2 0DL"
+  }
+}
+```
 
 ## Tag reference
 

--- a/index.js
+++ b/index.js
@@ -149,6 +149,9 @@ const swap = async (template, tags, formatter) => {
               replacement = parseInt(replacement)
               original = `"${tag.original}"`
               break
+            case 'toObject':
+              original = `"${tag.original}"`
+              break
             case 'toString':
               replacement = replacement.toString()
               break


### PR DESCRIPTION
Following on from <https://github.com/glynnbird/datamaker/pull/26>, this seems to do the trick and handles both array and objects:-

### name.js 

```javascript
import forename from "../forename.js";
import surname from "../surname.js";

export default () => {
  return {
    forename: forename(),
    surname: surname(),
  };
};
```

### template.json

```json
{
  "alive": "{{boolean 0.75 | toBool}}",
  "desc": "{{words 20}}",
  "address": "{{plugin:name | toObject}}",
}
```

`toObject` seemed to fit both scenarios since an array is technically a type of object.